### PR TITLE
feat: add opposing party collection step to legal intake flow

### DIFF
--- a/tests/unit/worker/opposingPartyIntake.test.ts
+++ b/tests/unit/worker/opposingPartyIntake.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runLegalIntakeAgent } from '../../../worker/agents/legalIntakeAgent';
+
+describe('Opposing Party Intake Flow', () => {
+  let mockEnv: any;
+
+  beforeEach(() => {
+    mockEnv = {
+      AI: {
+        run: vi.fn().mockResolvedValue({
+          response: 'Mock AI response'
+        })
+      },
+      DB: {
+        prepare: vi.fn().mockReturnValue({
+          bind: vi.fn().mockReturnValue({
+            run: vi.fn().mockResolvedValue({}),
+            first: vi.fn().mockResolvedValue(null),
+            all: vi.fn().mockResolvedValue({ results: [] })
+          })
+        })
+      },
+      CHAT_SESSIONS: {
+        put: vi.fn().mockResolvedValue(undefined),
+        get: vi.fn().mockResolvedValue(null)
+      }
+    };
+  });
+
+  describe('System Prompt Updates', () => {
+    it('should include opposing party step in conversation flow', async () => {
+      const messages = [
+        { isUser: true, content: 'I need help with a divorce' }
+      ];
+
+      // Mock AI response that asks for name
+      mockEnv.AI.run.mockResolvedValueOnce({
+        response: 'Can you please provide your full name?'
+      });
+
+      const result = await runLegalIntakeAgent(mockEnv, messages, 'test-team', 'test-session');
+
+      // Verify the AI was called with the updated system prompt
+      expect(mockEnv.AI.run).toHaveBeenCalledWith(
+        '@cf/meta/llama-3.1-8b-instruct',
+        expect.objectContaining({
+          messages: expect.arrayContaining([
+            expect.objectContaining({
+              role: 'system',
+              content: expect.stringContaining('opposing party')
+            })
+          ])
+        })
+      );
+
+      expect(result).toBeDefined();
+    });
+
+    it('should include opposing party in required information', async () => {
+      const messages = [
+        { isUser: true, content: 'I need help with a divorce' }
+      ];
+
+      // Mock AI response that asks for name
+      mockEnv.AI.run.mockResolvedValueOnce({
+        response: 'Can you please provide your full name?'
+      });
+
+      await runLegalIntakeAgent(mockEnv, messages, 'test-team', 'test-session');
+
+      // Verify the system prompt includes opposing party in the conversation flow
+      const systemPrompt = mockEnv.AI.run.mock.calls[0][1].messages[0].content;
+      
+      expect(systemPrompt).toContain('opposing party');
+      expect(systemPrompt).toContain('If name, location, phone, and email provided but no opposing party');
+      expect(systemPrompt).toContain('ALL information collected (name, location, phone, email, opposing party)');
+    });
+
+    it('should include opposing party in tool call examples', async () => {
+      const messages = [
+        { isUser: true, content: 'I need help with a divorce' }
+      ];
+
+      // Mock AI response that asks for name
+      mockEnv.AI.run.mockResolvedValueOnce({
+        response: 'Can you please provide your full name?'
+      });
+
+      await runLegalIntakeAgent(mockEnv, messages, 'test-team', 'test-session');
+
+      // Verify the system prompt includes opposing party in tool call examples
+      const systemPrompt = mockEnv.AI.run.mock.calls[0][1].messages[0].content;
+      
+      expect(systemPrompt).toContain('"opposing_party": "Jane Jobs"');
+    });
+  });
+
+  describe('Conversation Flow Steps', () => {
+    it('should follow the updated conversation flow with opposing party step', async () => {
+      const messages = [
+        { isUser: true, content: 'I need help with a divorce' }
+      ];
+
+      // Mock AI response that follows the conversation flow
+      mockEnv.AI.run.mockResolvedValueOnce({
+        response: 'Can you please provide your full name?'
+      });
+
+      await runLegalIntakeAgent(mockEnv, messages, 'test-team', 'test-session');
+
+      const systemPrompt = mockEnv.AI.run.mock.calls[0][1].messages[0].content;
+      
+      // Verify the conversation flow includes the opposing party step
+      const conversationFlowMatch = systemPrompt.match(/CONVERSATION FLOW - Follow exactly:([\s\S]*?)LOCATION VALIDATION:/);
+      expect(conversationFlowMatch).toBeTruthy();
+      
+      const flowSteps = conversationFlowMatch![1];
+      expect(flowSteps).toContain('5. If name, location, phone, and email provided but no opposing party');
+      expect(flowSteps).toContain('6. If ALL information collected (name, location, phone, email, opposing party)');
+    });
+  });
+}); 

--- a/worker/agents/legalIntakeAgent.ts
+++ b/worker/agents/legalIntakeAgent.ts
@@ -242,9 +242,10 @@ export async function runLegalIntakeAgent(env: any, messages: any[], teamId?: st
 2. If name provided but no location: ${locationPrompt}
 3. If name and location provided but no phone: "Thank you [name]! Now I need your phone number."
 4. If name, location, and phone provided but no email: "Thank you [name]! Now I need your email address."
-5. If ALL information collected (name, location, phone, email): Call create_matter tool immediately.
+5. If name, location, phone, and email provided but no opposing party: "Thank you [name]! For legal matters, it's helpful to know if there's an opposing party involved. Who is the other party in this situation? (If none, you can say 'none' or 'not applicable')"
+6. If ALL information collected (name, location, phone, email, opposing party): Call create_matter tool immediately.
 
-**CRITICAL: After collecting all contact information (name, location, phone, email), you MUST call the create_matter tool. Do not ask for more information if you have everything.**
+**CRITICAL: After collecting all contact information (name, location, phone, email, opposing party), you MUST call the create_matter tool. Do not ask for more information if you have everything.**
 
 **LOCATION VALIDATION:**
 - We validate user-provided locations against our service area
@@ -264,7 +265,7 @@ export async function runLegalIntakeAgent(env: any, messages: any[], teamId?: st
 - If unclear or general legal help → "General Consultation"
 
 **Available Tools:**
-- create_matter: Use when you have all required information (name, location, phone, email)
+- create_matter: Use when you have all required information (name, location, phone, email, opposing party)
 
 **Example Tool Call:**
 TOOL_CALL: create_matter
@@ -276,7 +277,7 @@ PARAMETERS: {
   "phone": "6159990000",
   "email": "hajas@yahoo.com",
   "location": "Charlotte, NC",
-  "opposing_party": ""
+  "opposing_party": "Jane Jobs"
 }
 
 **IMPORTANT: When calling create_matter, you MUST include:**
@@ -773,9 +774,10 @@ export async function runLegalIntakeAgentStream(
 2. If name provided but no location: ${locationPrompt}
 3. If name and location provided but no phone: "Thank you [name]! Now I need your phone number."
 4. If name, location, and phone provided but no email: "Thank you [name]! Now I need your email address."
-5. If ALL information collected (name, location, phone, email): Call create_matter tool immediately.
+5. If name, location, phone, and email provided but no opposing party: "Thank you [name]! For legal matters, it's helpful to know if there's an opposing party involved. Who is the other party in this situation? (If none, you can say 'none' or 'not applicable')"
+6. If ALL information collected (name, location, phone, email, opposing party): Call create_matter tool immediately.
 
-**CRITICAL: After collecting all contact information (name, location, phone, email), you MUST call the create_matter tool. Do not ask for more information if you have everything.**
+**CRITICAL: After collecting all contact information (name, location, phone, email, opposing party), you MUST call the create_matter tool. Do not ask for more information if you have everything.**
 
 **LOCATION VALIDATION:**
 - We validate user-provided locations against our service area
@@ -795,7 +797,7 @@ export async function runLegalIntakeAgentStream(
 - If unclear or general legal help → "General Consultation"
 
 **Available Tools:**
-- create_matter: Use when you have all required information (name, location, phone, email)
+- create_matter: Use when you have all required information (name, location, phone, email, opposing party)
 
 **Example Tool Call:**
 TOOL_CALL: create_matter
@@ -807,7 +809,7 @@ PARAMETERS: {
   "phone": "555-123-4567",
   "email": "john@example.com",
   "location": "Charlotte, NC",
-  "opposing_party": ""
+  "opposing_party": "ABC Company"
 }
 
 **IMPORTANT: When calling create_matter, you MUST include:**


### PR DESCRIPTION
- Updated system prompt to include step 5 for collecting opposing party information
- Modified conversation flow to ask for opposing party after collecting contact info
- Updated tool call examples to show opposing party values
- Added comprehensive tests to verify the changes
- Fixed issue #33: contextually ask for opposing party information if needed