### PR TITLE
feat: feature flag payment iframe and update payment button styling

### DIFF
--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -85,18 +85,13 @@ const Modal: FunctionComponent<ModalProps> = ({
                     
                     {/* Content */}
                     <motion.div 
-                        className={`shadow-2xl overflow-hidden ${
+                        className={`shadow-2xl overflow-hidden bg-white dark:bg-dark-bg text-gray-900 dark:text-white border border-gray-200 dark:border-dark-border ${
                             shouldUseDrawer 
                                 ? 'fixed bottom-0 left-0 right-0 rounded-t-2xl max-h-[90vh]' 
                                 : shouldUseFullscreen
                                 ? 'fixed inset-0 w-full h-full'
                                 : 'relative rounded-xl max-w-4xl w-full max-h-[90vh]'
                         }`}
-                        style={{
-                            backgroundColor: shouldUseFullscreen ? 'black' : 'var(--bg-color)',
-                            color: shouldUseFullscreen ? 'white' : 'var(--text-color)',
-                            border: shouldUseFullscreen ? 'none' : '1px solid var(--border-color)'
-                        }}
                         initial={shouldUseDrawer ? { y: "100%" } : { scale: 0.95 }}
                         animate={shouldUseDrawer ? { y: 0 } : { scale: 1 }}
                         exit={shouldUseDrawer ? { y: "100%" } : { scale: 0.95 }}
@@ -113,25 +108,18 @@ const Modal: FunctionComponent<ModalProps> = ({
                         {/* Handle for mobile drawer */}
                         {shouldUseDrawer && (
                             <div className="flex justify-center pt-4 pb-2">
-                                <div className="w-12 h-1 rounded-full" style={{ backgroundColor: 'var(--border-color)' }}></div>
+                                <div className="w-12 h-1 rounded-full bg-gray-300 dark:bg-gray-600"></div>
                             </div>
                         )}
                         
                         {/* Header */}
                         {(title || showCloseButton) && !shouldUseFullscreen && (
-                            <div 
-                                className="flex justify-between items-center p-4 border-b"
-                                style={{
-                                    backgroundColor: 'var(--input-bg)',
-                                    borderColor: 'var(--border-color)'
-                                }}
-                            >
-                                {title && <h3 className="text-base sm:text-lg lg:text-xl font-semibold m-0">{title}</h3>}
+                            <div className="flex justify-between items-center p-4 border-b border-gray-200 dark:border-dark-border bg-gray-50 dark:bg-gray-800">
+                                {title && <h3 className="text-base sm:text-lg lg:text-xl font-semibold m-0 text-gray-900 dark:text-white">{title}</h3>}
                                 {showCloseButton && (
                                     <button
                                         onClick={onClose}
-                                        className="p-1 rounded-md transition-colors"
-                                        style={{ color: 'var(--text-color)' }}
+                                        className="p-1 rounded-md transition-colors text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-700"
                                         aria-label="Close modal"
                                     >
                                         <XMarkIcon className="w-6 h-6" />

--- a/src/components/PaymentEmbed.tsx
+++ b/src/components/PaymentEmbed.tsx
@@ -3,6 +3,7 @@ import { ArrowTopRightOnSquareIcon, CreditCardIcon } from '@heroicons/react/24/o
 import { Button } from './ui/Button';
 import Modal from './Modal';
 import PaymentContent from './PaymentContent';
+import { features } from '../config/features';
 
 interface PaymentEmbedProps {
   paymentUrl: string;
@@ -44,41 +45,59 @@ const PaymentEmbed: FunctionComponent<PaymentEmbedProps> = ({
   return (
     <>
       <div className="flex flex-col sm:flex-row gap-3 my-4 w-full">
-        <Button
-          variant="primary"
-          size="lg"
-          onClick={handlePaymentClick}
-          style={{ backgroundColor: '#d4af37', color: '#1a1a1a' }}
-        >
-          <CreditCardIcon className="w-5 h-5 mr-2" />
-          Pay ${amount || '0'}
-        </Button>
-        
-        <Button
-          variant="secondary"
-          size="lg"
-          onClick={handleExternalLink}
-          className="flex-1 sm:flex-none"
-        >
-          <ArrowTopRightOnSquareIcon className="w-4 h-4 mr-2" />
-          Open in Browser
-        </Button>
+        {features.enablePaymentIframe ? (
+          // Show both buttons when iframe is enabled
+          <>
+            <Button
+              variant="primary"
+              size="lg"
+              onClick={handlePaymentClick}
+              className="bg-accent-500 text-gray-900 hover:bg-accent-600"
+            >
+              <CreditCardIcon className="w-5 h-5 mr-2" />
+              Pay ${amount || '0'}
+            </Button>
+            
+            <Button
+              variant="secondary"
+              size="lg"
+              onClick={handleExternalLink}
+              className="flex-1 sm:flex-none"
+            >
+              <ArrowTopRightOnSquareIcon className="w-4 h-4 mr-2" />
+              Open in Browser
+            </Button>
+          </>
+        ) : (
+          // Show only the primary payment button when iframe is disabled
+          <Button
+            variant="primary"
+            size="lg"
+            onClick={handleExternalLink}
+            className="bg-accent-500 text-gray-900 hover:bg-accent-600 w-full sm:w-auto"
+          >
+            <CreditCardIcon className="w-5 h-5 mr-2" />
+            Pay ${amount || '0'}
+          </Button>
+        )}
       </div>
       
-      <Modal
-        isOpen={showPaymentModal}
-        onClose={handlePaymentModalClose}
-        type="drawer"
-        mobileBehavior="drawer"
-        showCloseButton={true}
-      >
-        <PaymentContent
-          paymentUrl={paymentUrl}
-          amount={amount}
-          description={description}
-          onPaymentComplete={handlePaymentComplete}
-        />
-      </Modal>
+      {features.enablePaymentIframe && (
+        <Modal
+          isOpen={showPaymentModal}
+          onClose={handlePaymentModalClose}
+          type="drawer"
+          mobileBehavior="drawer"
+          showCloseButton={true}
+        >
+          <PaymentContent
+            paymentUrl={paymentUrl}
+            amount={amount}
+            description={description}
+            onPaymentComplete={handlePaymentComplete}
+          />
+        </Modal>
+      )}
     </>
   );
 };

--- a/src/config/features.ts
+++ b/src/config/features.ts
@@ -60,6 +60,13 @@ interface FeatureFlags {
      */
     enableMobileBottomNav: boolean;
 
+    /**
+     * Enable payment iframe/drawer functionality
+     * When false, only the "Open in Browser" button will be shown
+     * When true, both "Pay" button (opens drawer) and "Open in Browser" button will be shown
+     */
+    enablePaymentIframe: boolean;
+
       /**
    * Enable Paralegal Agent for matter formation
    * When false, all matter formation flows through the standard intake agent
@@ -86,6 +93,7 @@ const featureConfig: FeatureFlags = {
     enableLearnServicesButton: false, // Hide learn services button
     enableConsultationButton: false, // Hide consultation request button
     enableMobileBottomNav: false, // Temporarily hide mobile bottom nav
+    enablePaymentIframe: false, // Disable payment iframe/drawer - only show "Open in Browser" button
     enableParalegalAgent: false, // Paralegal agent disabled by default - enable per team
     paralegalFirst: false, // Intake-first flow by default - enable per team
 };


### PR DESCRIPTION
- Add enablePaymentIframe feature flag to control iframe/drawer functionality
- When disabled, show only primary 'Pay ' button that opens in new tab
- When enabled, show both 'Pay ' (opens drawer) and 'Open in Browser' buttons
- Fix payment drawer light/dark mode theming with proper Tailwind classes
- Remove hardcoded inline styles from payment buttons
- Set enablePaymentIframe to false by default (iframe disabled)